### PR TITLE
Oauth2 token expires before user session and generates  an Unauthorize Request

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,7 @@ security:
   enable_csrf: true
   require_ssl: true
   sessions: IF_REQUIRED
+
   user:
     name: admin
     password: ${ADMIN_PASSWORD:sandbox-admin}
@@ -37,6 +38,9 @@ management:
     enabled: true
   context-path: /manage
 server:
+  session:
+    timeout: 180
   tomcat:
     remote_ip_header: x-forwarded-for
     protocol_header: x-forwarded-proto
+


### PR DESCRIPTION
Session timeout should be reduced to expire before Oauth2 Token. So, it's going to force relogin on UI.
