### PR TITLE
Remove deprecated TRUSTED_CA_CERTIFICATE property

### DIFF
--- a/cf-manifest-reference.yml
+++ b/cf-manifest-reference.yml
@@ -27,9 +27,6 @@ applications:
     # Allow to disable SSL certificate check. SHOULD NOT BE disabled !!!
     # ENABLE_SSL_CERTIFICATE_CHECK: false
 
-    # Trusted Self-Signed Root CA Certificate to be added to JVM truststore
-    TRUSTED_CA_CERTIFICATE: ""
-
     # Sandbox service url - Required Parameter
     SANDBOX_SERVICE_URL: "set-your-sandbox-service-url"
 


### PR DESCRIPTION
This change removes deprecated TRUSTED_CA_CERTIFICATE property.

[#7]
